### PR TITLE
update sharp to 0.28.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/redis": "^2.8.26",
     "@types/request": "^2.48.5",
     "@types/request-ip": "0.0.35",
-    "@types/sharp": "^0.25.0",
+    "@types/sharp": "^0.28.3",
     "@types/uuid": "^7.0.2",
     "@types/validator": "^13.0.0",
     "aws-sdk": "^2.657.0",


### PR DESCRIPTION
I was getting the following node-gyp error on Arch Linux. Updating sharp fixes it.

```
npm ERR! code 1
npm ERR! path /opt/myDrive/node_modules/sharp
npm ERR! command failed
npm ERR! command sh -c (node install/libvips && node install/dll-copy && prebuild-install) || (node-gyp rebuild && node install/dll-copy)
npm ERR! make: Entering directory '/opt/myDrive/node_modules/sharp/build'
npm ERR!   TOUCH Release/obj.target/libvips-cpp.stamp
npm ERR!   CXX(target) Release/obj.target/sharp/src/common.o
npm ERR! make: Leaving directory '/opt/myDrive/node_modules/sharp/build'
npm ERR! info sharp Using cached /home/tv/.npm/_libvips/libvips-8.8.1-linux-x64.tar.gz
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@8.1.0
npm ERR! gyp info using node@16.6.0 | linux | x64
npm ERR! gyp info find Python using Python version 3.9.6 found at "/bin/python3"
npm ERR! (node:3690628) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
npm ERR! (Use `node --trace-deprecation ...` to show where the warning was created)
npm ERR! gyp info spawn /bin/python3
npm ERR! gyp info spawn args [
npm ERR! gyp info spawn args   '/usr/lib/node_modules/node-gyp/gyp/gyp_main.py',
npm ERR! gyp info spawn args   'binding.gyp',
npm ERR! gyp info spawn args   '-f',
npm ERR! gyp info spawn args   'make',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/opt/myDrive/node_modules/sharp/build/config.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/usr/lib/node_modules/node-gyp/addon.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/home/tv/.cache/node-gyp/16.6.0/include/node/common.gypi',
npm ERR! gyp info spawn args   '-Dlibrary=shared_library',
npm ERR! gyp info spawn args   '-Dvisibility=default',
npm ERR! gyp info spawn args   '-Dnode_root_dir=/home/tv/.cache/node-gyp/16.6.0',
npm ERR! gyp info spawn args   '-Dnode_gyp_dir=/usr/lib/node_modules/node-gyp',
npm ERR! gyp info spawn args   '-Dnode_lib_file=/home/tv/.cache/node-gyp/16.6.0/<(target_arch)/node.lib',
npm ERR! gyp info spawn args   '-Dmodule_root_dir=/opt/myDrive/node_modules/sharp',
npm ERR! gyp info spawn args   '-Dnode_engine=v8',
npm ERR! gyp info spawn args   '--depth=.',
npm ERR! gyp info spawn args   '--no-parallel',
npm ERR! gyp info spawn args   '--generator-output',
npm ERR! gyp info spawn args   'build',
npm ERR! gyp info spawn args   '-Goutput_dir=.'
npm ERR! gyp info spawn args ]
npm ERR! gyp info spawn make
npm ERR! gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm ERR! <command-line>: warning: "_GLIBCXX_USE_CXX11_ABI" redefined
npm ERR! <command-line>: note: this is the location of the previous definition
npm ERR! In file included from /home/tv/.cache/node-gyp/16.6.0/include/node/v8.h:30,
npm ERR!                  from /home/tv/.cache/node-gyp/16.6.0/include/node/node.h:63,
npm ERR!                  from ../src/common.cc:22:
npm ERR! /home/tv/.cache/node-gyp/16.6.0/include/node/v8-internal.h: In function ‘void v8::internal::PerformCastCheck(T*)’:
npm ERR! /home/tv/.cache/node-gyp/16.6.0/include/node/v8-internal.h:488:38: error: ‘remove_cv_t’ is not a member of ‘std’; did you mean ‘remove_cv’?
npm ERR!   488 |             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
npm ERR!       |                                      ^~~~~~~~~~~
npm ERR!       |                                      remove_cv
npm ERR! /home/tv/.cache/node-gyp/16.6.0/include/node/v8-internal.h:488:38: error: ‘remove_cv_t’ is not a member of ‘std’; did you mean ‘remove_cv’?
npm ERR!   488 |             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
npm ERR!       |                                      ^~~~~~~~~~~
npm ERR!       |                                      remove_cv
npm ERR! /home/tv/.cache/node-gyp/16.6.0/include/node/v8-internal.h:488:50: error: template argument 2 is invalid
npm ERR!   488 |             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
npm ERR!       |                                                  ^
npm ERR! /home/tv/.cache/node-gyp/16.6.0/include/node/v8-internal.h:488:63: error: ‘::Perform’ has not been declared
npm ERR!   488 |             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
npm ERR!       |                                                               ^~~~~~~
npm ERR! make: *** [sharp.target.mk:135: Release/obj.target/sharp/src/common.o] Error 1
npm ERR! gyp ERR! build error
npm ERR! gyp ERR! stack Error: `make` failed with exit code: 2
npm ERR! gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/node-gyp/lib/build.js:194:23)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:394:28)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
npm ERR! gyp ERR! System Linux 5.13.4-arch1-1
npm ERR! gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm ERR! gyp ERR! cwd /opt/myDrive/node_modules/sharp
npm ERR! gyp ERR! node -v v16.6.0
npm ERR! gyp ERR! node-gyp -v v8.1.0
npm ERR! gyp ERR! not ok
```

BTW, there are a ton of deprecation warnings. Do you want some help fixing those?
