### PR TITLE
fix ERR_INVALID_CHAR when filename contains non-ASCII characters

### DIFF
--- a/backend/services/chunk-service/utils/getFileData.ts
+++ b/backend/services/chunk-service/utils/getFileData.ts
@@ -10,6 +10,7 @@ import FileDB from "../../../db/mongoDB/fileDB";
 import { FileInterface } from "../../../models/file-model";
 import NotAuthorizedError from "../../../utils/NotAuthorizedError";
 import sanitizeFilename from "../../../utils/sanitizeFilename";
+import contentDisposition from "content-disposition";
 
 const fileDB = new FileDB();
 
@@ -133,12 +134,8 @@ const proccessData = (
 
       if (!range) {
         const sanatizedFilename = sanitizeFilename(currentFile.filename);
-        const encodedFilename = encodeURIComponent(sanatizedFilename);
         res.set("Content-Type", "binary/octet-stream");
-        res.set(
-          "Content-Disposition",
-          `attachment; filename="${sanatizedFilename}"; filename*=UTF-8''${encodedFilename}`
-        );
+        res.set("Content-Disposition", contentDisposition(sanatizedFilename));
         res.set("Content-Length", currentFile.metadata.size.toString());
       }
 

--- a/backend/services/chunk-service/utils/getPublicFileData.ts
+++ b/backend/services/chunk-service/utils/getPublicFileData.ts
@@ -10,6 +10,7 @@ import FileDB from "../../../db/mongoDB/fileDB";
 import NotAuthorizedError from "../../../utils/NotAuthorizedError";
 import UserDB from "../../../db/mongoDB/userDB";
 import sanitizeFilename from "../../../utils/sanitizeFilename";
+import contentDisposition from "content-disposition";
 
 const fileDB = new FileDB();
 const userDB = new UserDB();
@@ -65,12 +66,8 @@ const proccessData = (res: Response, fileID: string, tempToken: string) => {
       });
 
       const sanatizedFilename = sanitizeFilename(file.filename);
-      const encodedFilename = encodeURIComponent(sanatizedFilename);
       res.set("Content-Type", "binary/octet-stream");
-      res.set(
-        "Content-Disposition",
-        `attachment; filename="${sanatizedFilename}"; filename*=UTF-8''${encodedFilename}`
-      );
+      res.set("Content-Disposition", contentDisposition(sanatizedFilename));
       res.set("Content-Length", file.metadata.size.toString());
 
       readStream

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/compression": "^1.7.0",
     "@types/concat-stream": "^1.6.0",
     "@types/connect-busboy": "0.0.2",
+    "@types/content-disposition": "^0.5.9",
     "@types/cookie-parser": "^1.4.2",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",


### PR DESCRIPTION
Fixes

```
Express route error:  TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Content-Disposition"]
    at ServerResponse.setHeader (node:_http_outgoing:658:3)
    at ServerResponse.header (/usr/app-production/node_modules/express/lib/response.js:794:10)
    at /usr/app-production/dist-backend/services/chunk-service/utils/getFileData.js:101:21
    at Generator.next (<anonymous>)
    at fulfilled (/usr/app-production/dist-backend/services/chunk-service/utils/getFileData.js:5:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  code: 'ERR_INVALID_CHAR'
}
```